### PR TITLE
include packages

### DIFF
--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "target": "ES2022"
   },
-  "include": ["src"],
+  "include": ["packages", "src"],
   "exclude": [".*", "dist", "node_modules", "storybook-static", "build"],
   "ts-node": {
     "compilerOptions": {


### PR DESCRIPTION
Once `["src"]` was added the the tsconfig `includes` property, tsc was limited to only that directory and excluded others like `packages`.  As a side-effect, eslint throws errors because it has files included in its config but missing from the tsc compilation scope:

```
...sdk-xyo-react-js/src/types/images.d.ts
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/src/types/images.d.ts` using `parserOptions.project`: <tsconfigRootDir>tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```

In the @xyo-network/sdk-react, updating tsconfig to `"include": ["packages", "src"],` fixes these errors but wasn't sure if other repos might need other directories added.  Feel free to update or merge.